### PR TITLE
msm8939: Remove duplicate color correction node permission

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -267,10 +267,6 @@ on boot
     # camera sockets
     mkdir /data/misc/camera 0770 camera camera
 
-    # color
-    chown system system /sys/devices/virtual/graphics/fb0/rgb
-    chmod 0660 /sys/devices/virtual/graphics/fb0/rgb
-
     # Create directory used by display clients
     mkdir /data/misc/display 0770 system graphics
     mkdir /persist/display 0770 system graphics


### PR DESCRIPTION
- Defined in global CM init

Change-Id: I482a01cf96fc41b8cf36bdb3ba6046665eb11c6c
